### PR TITLE
switch from Any::Moose to Mouse

### DIFF
--- a/lib/Text/Handlebars/Compiler.pm
+++ b/lib/Text/Handlebars/Compiler.pm
@@ -1,5 +1,5 @@
 package Text::Handlebars::Compiler;
-use Any::Moose;
+use Mouse;
 
 extends 'Text::Xslate::Compiler';
 
@@ -647,7 +647,7 @@ sub merge_single_hash {
 sub literal { shift->parser->literal(@_) }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Mouse;
 
 =for Pod::Coverage
   define_helper

--- a/lib/Text/Handlebars/Symbol.pm
+++ b/lib/Text/Handlebars/Symbol.pm
@@ -1,5 +1,5 @@
 package Text::Handlebars::Symbol;
-use Any::Moose;
+use Mouse;
 
 extends 'Text::Xslate::Symbol';
 
@@ -14,6 +14,6 @@ has is_block_helper => (
 );
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Mouse;
 
 1;

--- a/lib/Text/Xslate/Syntax/Handlebars.pm
+++ b/lib/Text/Xslate/Syntax/Handlebars.pm
@@ -1,5 +1,5 @@
 package Text::Xslate::Syntax::Handlebars;
-use Any::Moose;
+use Mouse;
 
 use Carp 'confess';
 use Text::Xslate::Util qw($DEBUG $NUMBER neat p);
@@ -596,7 +596,7 @@ sub _field_to_string {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Mouse;
 
 =for Pod::Coverage
   call


### PR DESCRIPTION
Text::Xslate has switched to Mouse, causing this module to stop
working when Moose was loaded before it.  To see, try running:

 $ perl -MMoose -Ilib t/basic.t

with Text::Xslate v2.000.

Thanks and have a great day!

Cheers,
Fitz
