### PR TITLE
POD Update (Synopsis tweak)

### DIFF
--- a/lib/Text/Handlebars.pm
+++ b/lib/Text/Handlebars.pm
@@ -27,10 +27,10 @@ use Try::Tiny;
   my $vars = {
       author   => { firstName => 'Alan', lastName => 'Johnson' },
       body     => "I Love Handlebars",
-      comments => [
+      comments => [{
           author => { firstName => 'Yehuda', lastName => 'Katz' },
           body   => "Me too!",
-      ],
+      }],
   };
 
   say $handlebars->render_string(<<'TEMPLATE', $vars);


### PR DESCRIPTION
- If a user actually executes the synopsis it will not produce the
  results specified in the POD. Added the missing {} to make it work
  as demonstrated.
